### PR TITLE
Fix safari truncate issues in `entity-page-label`

### DIFF
--- a/client-v2/src/app/components/atoms/entity-page-label/entity-page-label.component.ts
+++ b/client-v2/src/app/components/atoms/entity-page-label/entity-page-label.component.ts
@@ -12,7 +12,7 @@ import { IconKey } from '../icons/icon/icons'
     styles: [
         `
             :host {
-                @apply truncate;
+                @apply pointer-events-none truncate text-left;
             }
         `,
     ],


### PR DESCRIPTION
### Changes/Additions

- Remove automatically added `title`
- Fix text alignment
